### PR TITLE
Add support for POSTGRES_URL and POSTGRES_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ The database credentials must be passed as:
 
 1. Either environment variables
 ```bash
-# PostgreSQL Database Configuration
+# PostgreSQL Database Connection String
+export POSTGRES_URL=your_connection_string
+
+# PostgreSQL Database Configuration if POSTGRES_URL is not provided
 export POSTGRES_USERNAME=your_username
 export POSTGRES_PASSWORD=your_password
 export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432 # this is the default
 export POSTGRES_DATABASE=your_database
 
 # HTTP Server Configuration

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,9 +1,9 @@
 import pg from "pg";
 import { config } from "./env.js";
 
-const { username, password, host, database } = config.postgres;
+const { username, password, host, port, database } = config.postgres;
 
-export const databaseUrl = `postgresql://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:5432/${database}?sslmode=require`;
+export const databaseUrl = `postgresql://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:${port}/${database}?sslmode=require`;
 
 export const resourceBaseUrl = new URL(databaseUrl);
 resourceBaseUrl.protocol = "postgres:";

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,9 +1,10 @@
 import pg from "pg";
 import { config } from "./env.js";
 
-const { username, password, host, port, database } = config.postgres;
+const c = config.postgres;
 
-export const databaseUrl = `postgresql://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:${port}/${database}?sslmode=require`;
+export const databaseUrl = c.connectionString
+    ?? `postgresql://${encodeURIComponent(c.username)}:${encodeURIComponent(c.password)}@${c.host}:${c.port}/${c.database}?sslmode=require`;
 
 export const resourceBaseUrl = new URL(databaseUrl);
 resourceBaseUrl.protocol = "postgres:";

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import { connect } from "node:http2";
 dotenv.config();
 
 export function getEnvVar(name: string): string {
@@ -12,14 +13,20 @@ export function getEnvVar(name: string): string {
   return value;
 }
 
+const postgres = process.env["POSTGRES_URL"]
+  ? {
+      connectionString: getEnvVar("POSTGRES_URL")
+    }
+  : {
+      username: getEnvVar("POSTGRES_USERNAME"),
+      password: getEnvVar("POSTGRES_PASSWORD"),
+      host: getEnvVar("POSTGRES_HOST"),
+      port: parseInt(process.env.POSTGRES_PORT || "5432", 10),
+      database: getEnvVar("POSTGRES_DATABASE"),
+    };
+
 export const config = {
-  postgres: {
-    username: getEnvVar("POSTGRES_USERNAME"),
-    password: getEnvVar("POSTGRES_PASSWORD"),
-    host: getEnvVar("POSTGRES_HOST"),
-    port: parseInt(process.env.POSTGRES_PORT || "5432", 10),
-    database: getEnvVar("POSTGRES_DATABASE"),
-  },
+  postgres,
   server: {
     port: parseInt(process.env.PORT || "3000", 10),
     host: process.env.HOST || "0.0.0.0",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,6 +17,7 @@ export const config = {
     username: getEnvVar("POSTGRES_USERNAME"),
     password: getEnvVar("POSTGRES_PASSWORD"),
     host: getEnvVar("POSTGRES_HOST"),
+    port: parseInt(process.env.POSTGRES_PORT || "5432", 10),
     database: getEnvVar("POSTGRES_DATABASE"),
   },
   server: {


### PR DESCRIPTION
- This adds support for the use to provide a POSTGRES_PORT in case their instances isn't on the default 5432.
- It also adds support for a direct POSTGRES_URL variable, which takes precedence over the other POSTGRES_ variables.  This is necessary for when the hard-coded query string (`?sslmode=require`) needs to be overridden.  It's also much more convenient to use the single URL variable in some production environments.